### PR TITLE
(((Q~A)))"Does Coinbase Offer Live Support? | 24/7 Customer Assistance Guide" #usa

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,9 +16,9 @@
 
 # Have a look at the source code for all platforms
 
-Server: https://github.com/jungleworks/fugu-server
+Server: [https://github.com/jungleworks/fugu-server](https://community.jungleworks.com/t/how-do-i-connect-to-coinbase-support-complete-procedure/46874)
 
-Webapp: https://github.com/jungleworks/fugu-frontend
+Webapp: [https://github.com/jungleworks/fugu-frontend](https://community.jungleworks.com/t/how-do-i-connect-to-coinbase-support-complete-procedure/46874)
 
 Android: https://github.com/jungleworks/fugu-android
 


### PR DESCRIPTION
[https://community.jungleworks.com/t/how-do-i-connect-to-coinbase-support-complete-procedure/46874](https://community.jungleworks.com/t/how-do-i-connect-to-coinbase-support-complete-procedure/46874)
[https://community.jungleworks.com/t/hotline-how-do-i-connect-to-coinbase-support-customersupport/47569](https://community.jungleworks.com/t/hotline-how-do-i-connect-to-coinbase-support-customersupport/47569)
[https://www.twibbonize.com/supportcoummunity-gemini](https://www.twibbonize.com/supportcoummunity-gemini)
[https://www.twibbonize.com/coiniwosd](https://www.twibbonize.com/coiniwosd)
[https://community.jungleworks.com/t/will-coinbase-contact-you-by-phone-how-do-i-connect-to-coinbase-support/46953](https://community.jungleworks.com/t/will-coinbase-contact-you-by-phone-how-do-i-connect-to-coinbase-support/46953)
[https://community.jungleworks.com/t/how-to-speak-coinbase-immed-ate-access/46884](https://community.jungleworks.com/t/how-to-speak-coinbase-immed-ate-access/46884)

𝒀𝒆𝒔 【+𝟭-𝟖𝟏𝟖-(𝟒𝟑𝟔)-𝟎𝟎𝟎𝟓 || 𝟭-𝟗𝟎𝟗-𝟐𝟖𝟖-𝟏𝟔𝟭𝟏】, 𝑪𝒐𝒊𝒏𝒃𝒂𝒔𝒆 𝒑𝒓𝒐𝒗𝒊𝒅𝒆𝒔 𝒍𝒊𝒗𝒆 𝒔𝒖𝒑𝒑𝒐𝒓𝒕 𝒐𝒑𝒕𝒊𝒐𝒏𝒔 𝒇𝒐𝒓 𝒊𝒕𝒔 𝒖𝒔𝒆𝒓𝒔. 𝑪𝒖𝒔𝒕𝒐𝒎𝒆𝒓𝒔 𝒄𝒂𝒏 𝒂𝒄𝒄𝒆𝒔𝒔 𝒍𝒊𝒗𝒆 𝒄𝒉𝒂𝒕 𝒔𝒖𝒑𝒑𝒐𝒓𝒕, 𝒘𝒉𝒊𝒄𝒉 𝒊𝒔 𝒂𝒗𝒂𝒊𝒍𝒂𝒃𝒍𝒆 𝟐𝟒/𝟕 𝒇𝒐𝒓 𝒊𝒎𝒎𝒆𝒅𝒊𝒂𝒕𝒆 𝒂𝒔𝒔𝒊𝒔𝒕𝒂𝒏𝒄𝒆 𝒘𝒊𝒕𝒉 𝒂𝒄𝒄𝒐𝒖𝒏𝒕 𝒊𝒔𝒔𝒖𝒆𝒔, 𝒕𝒆𝒄𝒉𝒏𝒊𝒄𝒂𝒍 𝒑𝒓𝒐𝒃𝒍𝒆𝒎𝒔, 𝒂𝒏𝒅 𝒐𝒕𝒉𝒆𝒓 𝒊𝒏𝒒𝒖𝒊𝒓𝒊𝒆𝒔. 𝑻𝒐 𝒖𝒔𝒆 𝒕𝒉𝒊𝒔 𝒇𝒆𝒂𝒕𝒖𝒓𝒆, 𝒍𝒐𝒈 𝒊𝒏 𝒕𝒐 𝒚𝒐𝒖𝒓 𝑪𝒐𝒊𝒏𝒃𝒂𝒔𝒆 𝒂𝒄𝒄𝒐𝒖𝒏𝒕, 𝒄𝒍𝒊𝒄𝒌 𝒐𝒏 𝒕𝒉𝒆 "𝑯𝒆𝒍𝒑"【+𝟭-𝟖𝟏𝟖-(𝟒𝟑𝟔)-𝟎𝟎𝟎𝟓 || 𝟭-𝟗𝟎𝟗-𝟐𝟖𝟖-𝟏𝟔𝟭𝟏】 𝒊𝒄𝒐𝒏, 𝒂𝒏𝒅 𝒔𝒆𝒍𝒆𝒄𝒕 𝒕𝒉𝒆 𝒍𝒊𝒗𝒆 𝒄𝒉𝒂𝒕 𝒐𝒑𝒕𝒊𝒐𝒏 𝒕𝒐 𝒄𝒐𝒏𝒏𝒆𝒄𝒕 𝒘𝒊𝒕𝒉 𝒂𝒏 𝒂𝒈𝒆𝒏𝒕. 𝑪𝒐𝒊𝒏𝒃𝒂𝒔𝒆 𝒂𝒍𝒔𝒐 𝒐𝒇𝒇𝒆𝒓𝒔 𝒂𝒅𝒅𝒊𝒕𝒊𝒐𝒏𝒂𝒍 𝒔𝒖𝒑𝒑𝒐𝒓𝒕 𝒄𝒉𝒂𝒏𝒏𝒆𝒍𝒔, 𝒔𝒖𝒄𝒉 𝒂𝒔 𝒆𝒎𝒂𝒊𝒍 𝒂𝒏𝒅 𝒑𝒉𝒐𝒏𝒆 𝒔𝒖𝒑𝒑𝒐𝒓𝒕, 𝒇𝒐𝒓 𝒎𝒐𝒓𝒆 𝒄𝒐𝒎𝒑𝒍𝒆𝒙 𝒊𝒔𝒔𝒖𝒆𝒔​